### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -42,7 +42,7 @@ class syntax_plugin_topbarsyntax extends DokuWiki_Syntax_Plugin
 /******************************************************************************/
 /* handle the match
 */   
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         global $ID;
         $match = substr($match,strlen('{{topbarsyntax>'),-2); //strip markup from start and end
         //handle params
@@ -56,7 +56,7 @@ class syntax_plugin_topbarsyntax extends DokuWiki_Syntax_Plugin
 * @author Michael Klier <chi@chimeric.de>
 * modified by Taggic <taggic@t-online.de>
 */   
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         $width = $data[0];   // width of the main bar
         $orient = $data[1];  // orientation of the menu
 


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
